### PR TITLE
[PIM-57] 반응형 보드페이지 구현

### DIFF
--- a/src/components/MobileHeader/MobileHeader.stories.tsx
+++ b/src/components/MobileHeader/MobileHeader.stories.tsx
@@ -1,0 +1,16 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { MobileHeader } from './MobileHeader';
+
+export default {
+  title: 'MobileHeader',
+  component: MobileHeader,
+} as ComponentMeta<typeof MobileHeader>;
+
+const Template: ComponentStory<typeof MobileHeader> = (args) => (
+  <MobileHeader {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  profileImg: 'assets/authorization/pimfy_profile.png',
+};

--- a/src/components/MobileHeader/MobileHeader.style.ts
+++ b/src/components/MobileHeader/MobileHeader.style.ts
@@ -1,12 +1,11 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { MobileHeaderProps } from './MobileHeader.types';
 
 export const Header = styled.div`
   display: flex;
   flex-direction: column;
-  height: 5%;
   width: 100%;
+  padding: 10px 20px;
 `;
 
 export const Wrapper = styled.div`
@@ -57,4 +56,22 @@ export const HeaderImg = styled.img<MobileHeaderProps>`
   width: 30px;
   border-radius: 50%;
   content: url(${(props) => props.profileImg});
+`;
+
+export const SideMenuWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: #ffffff;
+  background-color: #fca4be;
+
+  div {
+    width: 100%;
+    padding: 20px;
+    cursor: pointer;
+
+    :hover {
+      background-color: #e394ab;
+    }
+  }
 `;

--- a/src/components/MobileHeader/MobileHeader.style.ts
+++ b/src/components/MobileHeader/MobileHeader.style.ts
@@ -1,0 +1,60 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import { MobileHeaderProps } from './MobileHeader.types';
+
+export const Header = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 5%;
+  width: 100%;
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+
+  div {
+    width: 30%;
+  }
+`;
+
+export const TitleWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const MenuWrapper = styled.div`
+  color: #fca4be;
+  font-size: 20px;
+  cursor: pointer;
+`;
+
+export const ImgWrapper = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+export const Title = styled.p`
+  font-family: 'Rubik Bubbles', cursive;
+  font-size: 25px;
+  color: #fca4be;
+  text-transform: uppercase;
+  margin: 0;
+`;
+
+export const BoardName = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  color: #4f4e4e;
+  margin: 3px 0px;
+  font-size: 5px;
+`;
+
+export const HeaderImg = styled.img<MobileHeaderProps>`
+  width: 30px;
+  border-radius: 50%;
+  content: url(${(props) => props.profileImg});
+`;

--- a/src/components/MobileHeader/MobileHeader.style.ts
+++ b/src/components/MobileHeader/MobileHeader.style.ts
@@ -3,8 +3,10 @@ import { MobileHeaderProps } from './MobileHeader.types';
 
 export const Header = styled.div`
   display: flex;
+  position: fixed;
   flex-direction: column;
   width: 100%;
+  background-color: #ffffff;
   padding: 10px 20px;
 `;
 

--- a/src/components/MobileHeader/MobileHeader.tsx
+++ b/src/components/MobileHeader/MobileHeader.tsx
@@ -1,0 +1,23 @@
+import * as S from './MobileHeader.style';
+import { MobileHeaderProps } from './MobileHeader.types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars } from '@fortawesome/free-solid-svg-icons';
+
+export const MobileHeader = ({ profileImg }: MobileHeaderProps) => {
+  return (
+    <S.Header>
+      <S.Wrapper>
+        <S.MenuWrapper>
+          <FontAwesomeIcon icon={faBars} />
+        </S.MenuWrapper>
+        <S.TitleWrapper>
+          <S.Title>Prello</S.Title>
+        </S.TitleWrapper>
+        <S.ImgWrapper>
+          <S.HeaderImg profileImg={profileImg} />
+        </S.ImgWrapper>
+      </S.Wrapper>
+      <S.BoardName>First Board</S.BoardName>
+    </S.Header>
+  );
+};

--- a/src/components/MobileHeader/MobileHeader.tsx
+++ b/src/components/MobileHeader/MobileHeader.tsx
@@ -2,13 +2,19 @@ import * as S from './MobileHeader.style';
 import { MobileHeaderProps } from './MobileHeader.types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { useState } from 'react';
 
 export const MobileHeader = ({ profileImg }: MobileHeaderProps) => {
+  const [open, setOpen] = useState(false);
+
+  const handleClick = () => {
+    setOpen(!open);
+  };
   return (
     <S.Header>
       <S.Wrapper>
         <S.MenuWrapper>
-          <FontAwesomeIcon icon={faBars} />
+          <FontAwesomeIcon onClick={handleClick} icon={faBars} />
         </S.MenuWrapper>
         <S.TitleWrapper>
           <S.Title>Prello</S.Title>
@@ -18,6 +24,16 @@ export const MobileHeader = ({ profileImg }: MobileHeaderProps) => {
         </S.ImgWrapper>
       </S.Wrapper>
       <S.BoardName>First Board</S.BoardName>
+
+      {open ? (
+        <S.SideMenuWrapper>
+          <div>Workspace</div>
+          <div>Members</div>
+          <div>Settings</div>
+        </S.SideMenuWrapper>
+      ) : (
+        <></>
+      )}
     </S.Header>
   );
 };

--- a/src/components/MobileHeader/MobileHeader.types.ts
+++ b/src/components/MobileHeader/MobileHeader.types.ts
@@ -1,0 +1,5 @@
+import { ButtonHTMLAttributes, HTMLAttributes, ReactNode } from 'react';
+
+export interface MobileHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  profileImg?: string;
+}

--- a/src/components/SubHeader/SubHeader.style.ts
+++ b/src/components/SubHeader/SubHeader.style.ts
@@ -4,6 +4,7 @@ import { SubHeaderProps } from './SubHeader.types';
 
 export const Header = styled.div`
   display: flex;
+  position: fixed;
   height: 10%;
   width: 100%;
   background: #ffffff;

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -1,12 +1,13 @@
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
-import { useEffect, useState } from 'react';
-import * as S from './styles';
+import { MobileHeader } from '@/components/MobileHeader/MobileHeader';
 import SideBar from '@/components/SideBar/SideBar';
-import axios from 'axios';
-import { ReactSortable } from 'react-sortablejs';
-import Sortable from 'sortablejs';
 import { WithSearchBar } from '@/components/SubHeader/SubHeader.stories';
+import { Default, Mobile } from '@/utils/mediaQuery';
+import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+import Sortable from 'sortablejs';
+import * as S from './styles';
 
 export default function Board() {
   const [member, setMember] = useState([]);
@@ -45,12 +46,20 @@ export default function Board() {
 
   return (
     <S.Container>
-      <WithSearchBar
-        profileImg="public/assets/authorization/pimfy_profile.png"
-        searchBar={true}
-      />
+      <Default>
+        <WithSearchBar
+          profileImg="public/assets/authorization/pimfy_profile.png"
+          searchBar={true}
+        />
+      </Default>
+      <Mobile>
+        <MobileHeader profileImg="public/assets/authorization/pimfy_profile.png" />
+      </Mobile>
       <S.Wrapper>
-        <SideBar memberInfo={member} />
+        <Default>
+          <SideBar memberInfo={member} />
+        </Default>
+
         <S.RightWrapper className="column">
           <S.ListWrapper draggable="true">
             <S.ListHeader>
@@ -93,61 +102,6 @@ export default function Board() {
           </S.AddListWrapper>
         </S.RightWrapper>
       </S.Wrapper>
-      {/* 
-      <S.Header>
-        <S.HeaderLeftDiv>
-          <S.Title>Prello</S.Title>
-          <S.Divider />
-          <S.BoardName>First Board</S.BoardName>
-        </S.HeaderLeftDiv>
-        <S.HeaderRightDiv>
-          <S.SearchBar placeholder="Search" />
-          <S.HeaderImg />
-        </S.HeaderRightDiv>
-      </S.Header>
-      <S.Wrapper>
-        <SideBar memberInfo={member} />
-        <S.RightWrapper>
-          <S.ListWrapper>
-            <S.ListHeader>
-              <h1>To Do</h1>
-              <span>
-                <FontAwesomeIcon icon={faEllipsis} />
-              </span>
-            </S.ListHeader>
-            <S.ItemWrapper list={items} setList={setItems} group="shared">
-              {items.map((item) => (
-                <S.Item key={item.id}>{item.content}</S.Item>
-              ))}
-            </S.ItemWrapper>
-
-            <S.AddBtn onClick={handleAddItem}>
-              <span>+</span>
-              <S.AddBtnText>Add a card</S.AddBtnText>
-            </S.AddBtn>
-          </S.ListWrapper>
-          <S.ListWrapper>
-            <S.ListHeader>
-              <h1>Doing</h1>
-              <span>
-                <FontAwesomeIcon icon={faEllipsis} />
-              </span>
-            </S.ListHeader>
-            <S.ItemWrapper list={items2} setList={setItems2} group="shared">
-              {items2.map((item) => (
-                <S.Item key={item.id}>{item.content}</S.Item>
-              ))}
-            </S.ItemWrapper>
-            <S.AddBtn onClick={handleAddItem}>
-              <span>+</span>
-              <S.AddBtnText>Add a card</S.AddBtnText>
-            </S.AddBtn>
-          </S.ListWrapper>
-          <S.AddListWrapper>
-            <S.AddListBtn>+ ADD ANOTHER LIST</S.AddListBtn>
-          </S.AddListWrapper>
-        </S.RightWrapper>
-      </S.Wrapper> */}
     </S.Container>
   );
 }

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -60,43 +60,45 @@ export default function Board() {
           <SideBar memberInfo={member} />
         </Default>
 
-        <S.RightWrapper className="column">
-          <S.ListWrapper draggable="true">
-            <S.ListHeader>
-              <h1>To Do</h1>
-              <span>
-                <FontAwesomeIcon icon={faEllipsis} />
-              </span>
-            </S.ListHeader>
+        <S.RightWrapper>
+          <S.ListContainer className="column">
+            <S.ListWrapper draggable="true">
+              <S.ListHeader>
+                <h1>To Do</h1>
+                <span>
+                  <FontAwesomeIcon icon={faEllipsis} />
+                </span>
+              </S.ListHeader>
 
-            <S.ItemWrapper list={items} setList={setItems} group="shared">
-              {items.map((item) => (
-                <S.Item key={item.id}>{item.content}</S.Item>
-              ))}
-            </S.ItemWrapper>
-            <S.AddBtn onClick={handleAddItem}>
-              <span>+</span>
-              <S.AddBtnText>Add a card</S.AddBtnText>
-            </S.AddBtn>
-          </S.ListWrapper>
+              <S.ItemWrapper list={items} setList={setItems} group="shared">
+                {items.map((item) => (
+                  <S.Item key={item.id}>{item.content}</S.Item>
+                ))}
+              </S.ItemWrapper>
+              <S.AddBtn onClick={handleAddItem}>
+                <span>+</span>
+                <S.AddBtnText>Add a card</S.AddBtnText>
+              </S.AddBtn>
+            </S.ListWrapper>
 
-          <S.ListWrapper draggable="true">
-            <S.ListHeader>
-              <h1>Doing</h1>
-              <span>
-                <FontAwesomeIcon icon={faEllipsis} />
-              </span>
-            </S.ListHeader>
-            <S.ItemWrapper list={items2} setList={setItems2} group="shared">
-              {items2.map((item) => (
-                <S.Item key={item.id}>{item.content}</S.Item>
-              ))}
-            </S.ItemWrapper>
-            <S.AddBtn onClick={handleAddItem}>
-              <span>+</span>
-              <S.AddBtnText>Add a card</S.AddBtnText>
-            </S.AddBtn>
-          </S.ListWrapper>
+            <S.ListWrapper draggable="true">
+              <S.ListHeader>
+                <h1>Doing</h1>
+                <span>
+                  <FontAwesomeIcon icon={faEllipsis} />
+                </span>
+              </S.ListHeader>
+              <S.ItemWrapper list={items2} setList={setItems2} group="shared">
+                {items2.map((item) => (
+                  <S.Item key={item.id}>{item.content}</S.Item>
+                ))}
+              </S.ItemWrapper>
+              <S.AddBtn onClick={handleAddItem}>
+                <span>+</span>
+                <S.AddBtnText>Add a card</S.AddBtnText>
+              </S.AddBtn>
+            </S.ListWrapper>
+          </S.ListContainer>
           <S.AddListWrapper>
             <S.AddListBtn>+ ADD ANOTHER LIST</S.AddListBtn>
           </S.AddListWrapper>

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -60,49 +60,97 @@ export default function Board() {
           <SideBar memberInfo={member} />
         </Default>
 
-        <S.RightWrapper>
-          <S.ListContainer className="column">
-            <S.ListWrapper draggable="true">
-              <S.ListHeader>
-                <h1>To Do</h1>
-                <span>
-                  <FontAwesomeIcon icon={faEllipsis} />
-                </span>
-              </S.ListHeader>
+        <Default>
+          <S.RightWrapper>
+            <S.ListContainer className="column">
+              <S.ListWrapper draggable="true">
+                <S.ListHeader>
+                  <h1>To Do</h1>
+                  <span>
+                    <FontAwesomeIcon icon={faEllipsis} />
+                  </span>
+                </S.ListHeader>
 
-              <S.ItemWrapper list={items} setList={setItems} group="shared">
-                {items.map((item) => (
-                  <S.Item key={item.id}>{item.content}</S.Item>
-                ))}
-              </S.ItemWrapper>
-              <S.AddBtn onClick={handleAddItem}>
-                <span>+</span>
-                <S.AddBtnText>Add a card</S.AddBtnText>
-              </S.AddBtn>
-            </S.ListWrapper>
+                <S.ItemWrapper list={items} setList={setItems} group="shared">
+                  {items.map((item) => (
+                    <S.Item key={item.id}>{item.content}</S.Item>
+                  ))}
+                </S.ItemWrapper>
+                <S.AddBtn onClick={handleAddItem}>
+                  <span>+</span>
+                  <S.AddBtnText>Add a card</S.AddBtnText>
+                </S.AddBtn>
+              </S.ListWrapper>
 
-            <S.ListWrapper draggable="true">
-              <S.ListHeader>
-                <h1>Doing</h1>
-                <span>
-                  <FontAwesomeIcon icon={faEllipsis} />
-                </span>
-              </S.ListHeader>
-              <S.ItemWrapper list={items2} setList={setItems2} group="shared">
-                {items2.map((item) => (
-                  <S.Item key={item.id}>{item.content}</S.Item>
-                ))}
-              </S.ItemWrapper>
-              <S.AddBtn onClick={handleAddItem}>
-                <span>+</span>
-                <S.AddBtnText>Add a card</S.AddBtnText>
-              </S.AddBtn>
-            </S.ListWrapper>
-          </S.ListContainer>
-          <S.AddListWrapper>
-            <S.AddListBtn>+ ADD ANOTHER LIST</S.AddListBtn>
-          </S.AddListWrapper>
-        </S.RightWrapper>
+              <S.ListWrapper draggable="true">
+                <S.ListHeader>
+                  <h1>Doing</h1>
+                  <span>
+                    <FontAwesomeIcon icon={faEllipsis} />
+                  </span>
+                </S.ListHeader>
+                <S.ItemWrapper list={items2} setList={setItems2} group="shared">
+                  {items2.map((item) => (
+                    <S.Item key={item.id}>{item.content}</S.Item>
+                  ))}
+                </S.ItemWrapper>
+                <S.AddBtn onClick={handleAddItem}>
+                  <span>+</span>
+                  <S.AddBtnText>Add a card</S.AddBtnText>
+                </S.AddBtn>
+              </S.ListWrapper>
+            </S.ListContainer>
+            <S.AddListWrapper>
+              <S.AddListBtn>+ ADD ANOTHER LIST</S.AddListBtn>
+            </S.AddListWrapper>
+          </S.RightWrapper>
+        </Default>
+
+        <Mobile>
+          <S.MobileRightWrapper>
+            <S.ListMobileContiner className="column">
+              <S.MobileListWrapper draggable="true">
+                <S.ListHeader>
+                  <h1>To Do</h1>
+                  <span>
+                    <FontAwesomeIcon icon={faEllipsis} />
+                  </span>
+                </S.ListHeader>
+
+                <S.ItemWrapper list={items} setList={setItems} group="shared">
+                  {items.map((item) => (
+                    <S.Item key={item.id}>{item.content}</S.Item>
+                  ))}
+                </S.ItemWrapper>
+                <S.AddBtn onClick={handleAddItem}>
+                  <span>+</span>
+                  <S.AddBtnText>Add a card</S.AddBtnText>
+                </S.AddBtn>
+              </S.MobileListWrapper>
+
+              <S.MobileListWrapper draggable="true">
+                <S.ListHeader>
+                  <h1>Doing</h1>
+                  <span>
+                    <FontAwesomeIcon icon={faEllipsis} />
+                  </span>
+                </S.ListHeader>
+                <S.ItemWrapper list={items2} setList={setItems2} group="shared">
+                  {items2.map((item) => (
+                    <S.Item key={item.id}>{item.content}</S.Item>
+                  ))}
+                </S.ItemWrapper>
+                <S.AddBtn onClick={handleAddItem}>
+                  <span>+</span>
+                  <S.AddBtnText>Add a card</S.AddBtnText>
+                </S.AddBtn>
+              </S.MobileListWrapper>
+            </S.ListMobileContiner>
+            <S.MobileAddListWrapper>
+              <S.AddListBtn>+ ADD ANOTHER LIST</S.AddListBtn>
+            </S.MobileAddListWrapper>
+          </S.MobileRightWrapper>
+        </Mobile>
       </S.Wrapper>
     </S.Container>
   );

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -10,7 +10,9 @@ export const Container = styled.div`
 export const Wrapper = styled.div`
   display: flex;
   height: 90%;
+  min-width: 100vh;
   background: #f5f5f5;
+  margin-top: 10%;
 `;
 
 export const LeftWrapper = styled.div`

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -4,7 +4,7 @@ import { ReactSortable } from 'react-sortablejs';
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  max-height: 100vh;
+  height: 100vh;
 `;
 
 export const Wrapper = styled.div`

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -58,7 +58,10 @@ export const HorDivider = styled.div`
 
 export const RightWrapper = styled.div`
   display: flex;
-  width: 80%;
+`;
+
+export const ListContainer = styled.div`
+  display: flex;
 `;
 
 export const ListWrapper = styled.div`
@@ -67,7 +70,7 @@ export const ListWrapper = styled.div`
   align-items: center;
   color: #606060;
 
-  width: 20%;
+  width: 250px;
   height: fit-content;
   padding: 40px 0px 20px 0px;
   background: #ffffff;

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -21,8 +21,19 @@ export const RightWrapper = styled.div`
   padding-right: 25px;
 `;
 
+export const MobileRightWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: center;
+`;
+
 export const ListContainer = styled.div`
   display: flex;
+`;
+export const ListMobileContiner = styled.div`
+  display: flex;
+  flex-direction: column;
 `;
 
 export const ListWrapper = styled.div`
@@ -42,6 +53,10 @@ export const ListWrapper = styled.div`
   margin-top: 30px;
   justify-content: center;
   cursor: pointer;
+`;
+
+export const MobileListWrapper = styled(ListWrapper)`
+  width: 350px;
 `;
 
 export const ListHeader = styled.div`
@@ -97,4 +112,9 @@ export const AddListBtn = styled.div`
 
 export const AddListWrapper = styled(ListWrapper)`
   padding: 15px 40px;
+`;
+
+export const MobileAddListWrapper = styled(ListWrapper)`
+  width: 350px;
+  padding: 15px;
 `;

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -12,7 +12,7 @@ export const Wrapper = styled.div`
   height: 90%;
   min-width: 100vh;
   background: #f5f5f5;
-  margin-top: 10%;
+  margin-top: 65px;
 `;
 
 export const LeftWrapper = styled.div`

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -9,57 +9,16 @@ export const Container = styled.div`
 
 export const Wrapper = styled.div`
   display: flex;
-  height: 90%;
-  min-width: 100vh;
   background: #f5f5f5;
-  margin-top: 65px;
-`;
-
-export const LeftWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 20%;
-  padding: 20px 25px;
-  color: #4f4e4e;
-`;
-
-export const BarInfo = styled.div`
+  height: 100%;
   width: 100%;
-  display: flex;
-`;
-
-export const BarImg = styled.img`
-  height: 50px;
-  border-radius: 17px;
-`;
-
-export const WorkspaceName = styled.h1`
-  margin-left: 20px;
-  font-size: 20px;
-  font-weight: bold;
-`;
-
-export const MenuWrapper = styled.div`
-  height: 65%;
-`;
-
-export const Menu = styled.div`
-  font-size: 20px;
-  font-weight: bold;
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 15px;
-  padding: 10px;
-`;
-
-export const HorDivider = styled.div`
-  border-bottom: 0.5px solid #383838;
-  height: 1px;
-  margin: 20px 0px;
+  margin-top: 65px;
 `;
 
 export const RightWrapper = styled.div`
   display: flex;
+  background: #f5f5f5;
+  padding-right: 25px;
 `;
 
 export const ListContainer = styled.div`


### PR DESCRIPTION
## 반응형 보드페이지 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
PIM-57
<!-- PIM-xxxx -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링
- [x] UI 구현 및 변경

### 구현 내용
<img width="542" alt="스크린샷 2023-01-19 오전 10 23 58" src="https://user-images.githubusercontent.com/63714074/213333969-b4e1b487-0a66-488e-a046-37294aaf53b4.png">
<img width="542" alt="스크린샷 2023-01-19 오전 10 23 48" src="https://user-images.githubusercontent.com/63714074/213333977-e162f3f1-0938-4fed-afeb-ce75f4732f2e.png">

- 보드 페이지 ➡️ 반응형으로 구현
- 모바일 헤더 및 사이드바 컴포넌트 생성
- 기존의 버그 수정
    - 리스트의 순서를 바꿀때, `  + add another list  `의 위치까지 바뀌던 오류 수정

### 리뷰 포인트
화면 크기에 따라서 헤더와 사이드바 영역이 사진과 같이 변경되는 지 같이 확인해주세요

<!-- 오류 있는지 함께 확인해주세요 -->

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
