### PR TITLE
[PIM-62] 로그인 정보 저장하는 recoil 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@mui/material": "^5.11.4",
-    "@types/sortablejs": "^1.15.0",
     "@types/react-responsive": "^8.0.5",
+    "@types/sortablejs": "^1.15.0",
     "@vitejs/plugin-react-refresh": "^1.3.6",
     "axios": "^1.2.2",
     "emotion-reset": "^3.0.1",
@@ -34,6 +34,7 @@
     "react-responsive": "^9.0.2",
     "react-router-dom": "^6.6.2",
     "react-sortablejs": "^6.1.4",
+    "recoil": "^0.7.6",
     "sortablejs": "^1.15.0",
     "vite-plugin-linter": "^2.0.2",
     "vite-plugin-pages": "^0.28.0"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,56 +1,61 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { DBConfig } from './utils/dbconfig';
-import { initDB } from 'react-indexed-db';
-import { IndexedDB } from 'react-indexed-db';
+import { IndexedDB, initDB } from 'react-indexed-db';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import Login from './pages/authorization/login';
 import SignUp from './pages/authorization/sign-up';
-import routes from './routes';
-import Main from './pages/main';
 import Board from './pages/board';
+import Main from './pages/main';
+import NotFound from './pages/notFound';
 import WorkspaceDefault from './pages/workspace/default';
 import WorkspaceDetail from './pages/workspace/detail';
-import NotFound from './pages/notFound';
+import routes from './routes';
+import { DBConfig } from './utils/dbconfig';
 initDB(DBConfig);
 
 function App() {
   return (
     <BrowserRouter>
-      <IndexedDB
-        name="MyDB"
-        version={1}
-        objectStoresMeta={[
-          {
-            store: 'user',
-            storeConfig: { keyPath: 'id', autoIncrement: true },
-            storeSchema: [
-              { name: 'email', keypath: 'email', options: { unique: false } },
-              {
-                name: 'password',
-                keypath: 'password',
-                options: { unique: false },
-              },
-              {
-                name: 'nickname',
-                keypath: 'nickname',
-                options: { unique: true },
-              },
-            ],
-          },
-        ]}
-      >
-        <Routes>
-          <Route path={routes.LOGIN} element={<Login />} />
-          <Route path={routes.MAIN} element={<Main />} />
-          <Route path={routes.SIGNUP} element={<SignUp />} />
-          <Route path={routes.BOARD} element={<Board />} />
-          <Route
-            path={routes.WORKSPACEDEFAULT}
-            element={<WorkspaceDefault />}
-          />
-          <Route path={routes.WORKSPACEDETAIL} element={<WorkspaceDetail />} />
-          <Route path={'*'} element={<NotFound />} />
-        </Routes>
-      </IndexedDB>
+      <RecoilRoot>
+        <IndexedDB
+          name="MyDB"
+          version={1}
+          objectStoresMeta={[
+            {
+              store: 'user',
+              storeConfig: { keyPath: 'id', autoIncrement: true },
+              storeSchema: [
+                { name: 'email', keypath: 'email', options: { unique: false } },
+                {
+                  name: 'password',
+                  keypath: 'password',
+                  options: { unique: false },
+                },
+                {
+                  name: 'nickname',
+                  keypath: 'nickname',
+                  options: { unique: true },
+                },
+              ],
+            },
+          ]}
+        >
+          <Routes>
+            <Route path={routes.LOGIN} element={<Login />} />
+            <Route path={routes.MAIN} element={<Main />} />
+            <Route path={routes.SIGNUP} element={<SignUp />} />
+            <Route path={routes.BOARD} element={<Board />} />
+            <Route
+              path={routes.WORKSPACEDEFAULT}
+              element={<WorkspaceDefault />}
+            />
+            <Route
+              path={routes.WORKSPACEDETAIL}
+              element={<WorkspaceDetail />}
+            />
+            <Route path={'*'} element={<NotFound />} />
+          </Routes>
+        </IndexedDB>
+      </RecoilRoot>
     </BrowserRouter>
   );
 }

--- a/src/pages/authorization/login/index.tsx
+++ b/src/pages/authorization/login/index.tsx
@@ -5,12 +5,17 @@ import routes from '@/routes';
 import { useIndexedDB } from 'react-indexed-db';
 import { pwdRegex } from '@/utils/checkPassword';
 import { emailRegex } from '@/utils/checkEmail';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { userSelector } from '@/utils/atom/userSelector';
+
 function Login() {
   const [login, setLogin] = useState<boolean>(false);
   const [email, setEmail] = useState<string>('');
   const [password, setPassword] = useState<string>('');
   const [emailValidation, setEmailValidation] = useState<boolean>(true);
   const [pwdValidation, setPwdValidation] = useState<boolean>(true);
+  const [user, setUser] = useRecoilState(userSelector);
+
   const navigate = useNavigate();
   const { getByIndex } = useIndexedDB('user');
 
@@ -48,7 +53,7 @@ function Login() {
           getByIndex('email', email)
             .then(
               (personFromDB) => {
-                console.log(personFromDB);
+                setUser(personFromDB);
               },
               (error) => {
                 console.log(error);

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -1,13 +1,13 @@
 import Button from '@/components/Button/Button';
+import { MobileHeader } from '@/components/MobileHeader/MobileHeader';
 import ProfileImg from '@/components/ProfileImg/ProfileImg';
 import { SubHeader } from '@/components/SubHeader/SubHeader';
+import { userSelector } from '@/utils/atom/userSelector';
 import { Default, Mobile } from '@/utils/mediaQuery';
 import Grid from '@mui/material/Grid';
 import { useNavigate } from 'react-router-dom';
-import * as S from './styles';
-import { MobileHeader } from '@/components/MobileHeader/MobileHeader';
-import { userSelector } from '@/utils/atom/userSelector';
 import { useRecoilValue } from 'recoil';
+import * as S from './styles';
 export default function WorkspaceDefault() {
   const navigate = useNavigate();
   const user = useRecoilValue(userSelector);

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -4,8 +4,12 @@ import * as S from './styles';
 import Button from '@/components/Button/Button';
 import ProfileImg from '@/components/ProfileImg/ProfileImg';
 import { Mobile, Default } from '@/utils/mediaQuery';
+import { userSelector } from '@/utils/atom/userSelector';
+import { useRecoilValue } from 'recoil';
 export default function WorkspaceDefault() {
   const navigate = useNavigate();
+  const user = useRecoilValue(userSelector);
+  console.log(user);
   return (
     <S.Container>
       <S.Wrapper>

--- a/src/utils/atom/user.ts
+++ b/src/utils/atom/user.ts
@@ -1,0 +1,18 @@
+import { atom } from 'recoil';
+
+export interface IUser {
+  id: number;
+  email: string;
+  password: string;
+  nickname: string;
+}
+
+export const userState = atom<IUser | {}>({
+  key: 'userState',
+  default: {
+    id: 0,
+    email: '',
+    password: '',
+    nickname: '',
+  },
+});

--- a/src/utils/atom/userSelector.ts
+++ b/src/utils/atom/userSelector.ts
@@ -1,0 +1,14 @@
+import { selector } from 'recoil';
+import { IUser } from './user';
+import { userState } from './user';
+
+export const userSelector = selector<IUser | {}>({
+  key: 'userSelector',
+  get: ({ get }) => {
+    get(userState);
+    return userState;
+  },
+  set: ({ set }, newValue) => {
+    set(userState, { ...newValue });
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -8117,6 +8117,11 @@ grapheme-splitter@^1.0.4:
   resolved "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz"
   integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz"
@@ -12104,6 +12109,13 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+recoil@^0.7.6:
+  version "0.7.6"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.6.tgz#75297ecd70bbfeeb72e861aa6141a86bb6dfcd5e"
+  integrity sha512-hsBEw7jFdpBCY/tu2GweiyaqHKxVj6EqF2/SfrglbKvJHhpN57SANWvPW+gE90i3Awi+A5gssOd3u+vWlT+g7g==
+  dependencies:
+    hamt_plus "1.0.2"
 
 redent@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## 로그인 정보 저장하는 recoil 구현

### 지라 티켓 번호
PIM-62

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링
- [ ] UI 구현 및 변경

### 구현 내용
<!-- 구글 소셜 로그인 연동 -->
<!-- 테스트 결과 포함 -->
- 로그인 성공 시 해당 유저의 정보를 `indexd-db`에서 불러와 `userState`에 저장
- `recoil atoms`가 아닌 `selector`로 관리하도록 했습니다!
### 리뷰 포인트
![image](https://user-images.githubusercontent.com/81613151/214468058-72837cc8-2de1-4187-b8cd-cd92f50bbc34.png)
로그인 성공 시 콘솔창에 recoil에 저장된 유저정보가 잘 출력되는지 확인해주세요!
<!-- 오류 있는지 함께 확인해주세요 -->

### TODO
- [x] 로그인 테스트 코드 작성