### PR TITLE
[PIM-79] 워크스페이스 조회 모킹 API 생성

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ function App() {
                 {
                   name: 'memberInfo',
                   keypath: 'memberInfo',
-                  options: { unique: true },
+                  options: { unique: false },
                 },
               ],
             },

--- a/src/components/Modals/CreateModal/CreateModal.tsx
+++ b/src/components/Modals/CreateModal/CreateModal.tsx
@@ -62,6 +62,7 @@ export const CreateWorkspace = (props: any) => {
       const response = await axios.post('/workspace/create', info);
       if (response.status === 200) {
         props.setOpenModal(false);
+        props.fetchWorkspaces();
       }
     } catch (error: any) {
       console.log(error);

--- a/src/components/Modals/CreateModal/CreateModal.tsx
+++ b/src/components/Modals/CreateModal/CreateModal.tsx
@@ -9,11 +9,6 @@ import axios from 'axios';
 import { userSelector } from '@/recoil/atom/userSelector';
 import { useRecoilState } from 'recoil';
 
-interface IInvitedEmail {
-  key: number;
-  label: string;
-}
-
 const ListItem = styled('li')(({ theme }) => ({
   margin: theme.spacing(0.5),
 }));
@@ -25,13 +20,6 @@ export const CreateWorkspace = (props: any) => {
   const [summary, setSummary] = useState<string>('');
   const [newEmail, setNewEmail] = useState<string>('');
   const [emailList, setEmailList] = useState<string[]>([]);
-  const [invitedEmails, setInviteEmails] = useState<readonly IInvitedEmail[]>([
-    { key: 0, label: 'test@gmail.com' },
-    { key: 1, label: 'test2@gmail.com' },
-    { key: 2, label: 'test3@gmail.com' },
-    { key: 3, label: 'test4@gmail.com' },
-    { key: 4, label: 'test5@gmail.com' },
-  ]);
 
   const handleModal = () => {
     props.setOpenModal(false);

--- a/src/mocks/workspaceHandlers.ts
+++ b/src/mocks/workspaceHandlers.ts
@@ -24,15 +24,24 @@ export const workspaceHandlers = [
   }),
 
   rest.get('/workspace/list', async (req, res, ctx) => {
+    let CWorkspaces: IWorkspace[] = [];
+
+    const email = 'test@gmail.com';
+    await getAll().then((workspaces: IWorkspace[]) => {
+      CWorkspaces = workspaces.filter(({ owner }) => owner === email);
+    });
+
+    return res(ctx.status(200), ctx.json(CWorkspaces));
+  }),
+
+  rest.get('/workspace/list/participate', async (req, res, ctx) => {
     let PWorkspaces: IWorkspace[] = [];
 
     const email = 'test@gmail.com';
     await getAll().then((workspaces: IWorkspace[]) => {
-      PWorkspaces = workspaces.filter(({ owner }) => owner === email);
-
       {
         workspaces.map((workspace) =>
-          workspace.memberInfo.includes('test@gmail.com')
+          workspace.memberInfo.includes(email)
             ? (PWorkspaces = [...PWorkspaces, workspace])
             : (PWorkspaces = PWorkspaces),
         );

--- a/src/mocks/workspaceHandlers.ts
+++ b/src/mocks/workspaceHandlers.ts
@@ -1,6 +1,15 @@
+import { getAllByAltText } from '@testing-library/react';
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
-const { add } = useIndexedDB('workspace');
+const { getAll, add } = useIndexedDB('workspace');
+
+type IWorkspace = {
+  owner: string;
+  name: string;
+  summary: string;
+  memberInfo: string[];
+};
+
 export const workspaceHandlers = [
   rest.post('/workspace/create', async (req: any, res, ctx) => {
     try {
@@ -12,5 +21,24 @@ export const workspaceHandlers = [
     } catch (error) {
       return res(ctx.status(500), ctx.json({ message: 'Store in DB Failed!' }));
     }
+  }),
+
+  rest.get('/workspace', async (req, res, ctx) => {
+    let PWorkspaces: IWorkspace[] = [];
+
+    const email = 'test@gmail.com';
+    await getAll().then((workspaces: IWorkspace[]) => {
+      PWorkspaces = workspaces.filter(({ owner }) => owner === email);
+
+      {
+        workspaces.map((workspace) =>
+          workspace.memberInfo.includes('test@gmail.com')
+            ? (PWorkspaces = [...PWorkspaces, workspace])
+            : (PWorkspaces = PWorkspaces),
+        );
+      }
+    });
+
+    return res(ctx.status(200), ctx.json(PWorkspaces));
   }),
 ];

--- a/src/mocks/workspaceHandlers.ts
+++ b/src/mocks/workspaceHandlers.ts
@@ -23,7 +23,7 @@ export const workspaceHandlers = [
     }
   }),
 
-  rest.get('/workspace', async (req, res, ctx) => {
+  rest.get('/workspace/list', async (req, res, ctx) => {
     let PWorkspaces: IWorkspace[] = [];
 
     const email = 'test@gmail.com';

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -26,24 +26,24 @@ export default function WorkspaceDefault() {
   }, [isOpenModal]);
 
   useEffect(() => {
-    const fetchWorkspaces = async () => {
-      try {
-        setError(null);
-        setWorkspaces(null);
-        setLoading(true);
-
-        const response = await axios.get('/workspace');
-        if (response.status === 200) {
-          setWorkspaces(response.data);
-        }
-      } catch (error: any) {
-        setError(error);
-      }
-      setLoading(false);
-    };
-
     fetchWorkspaces();
   }, []);
+
+  const fetchWorkspaces = async () => {
+    try {
+      setError(null);
+      setWorkspaces(null);
+      setLoading(true);
+
+      const response = await axios.get('/workspace');
+      if (response.status === 200) {
+        setWorkspaces(response.data);
+      }
+    } catch (error: any) {
+      setError(error);
+    }
+    setLoading(false);
+  };
 
   if (loading) return <div>로딩중..</div>;
   if (error) return <div>에러가 발생했습니다</div>;
@@ -61,7 +61,10 @@ export default function WorkspaceDefault() {
         <MobileHeader profileImg="public/assets/authorization/pimfy_profile.png" />
       </Mobile>
       {isOpenModal && (
-        <CreateWorkspace setOpenModal={setOpenModal}></CreateWorkspace>
+        <CreateWorkspace
+          setOpenModal={setOpenModal}
+          fetchWorkspaces={fetchWorkspaces}
+        ></CreateWorkspace>
       )}
       <S.ContentsWrapper>
         <S.Wrapper>

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -9,17 +9,45 @@ import Grid from '@mui/material/Grid';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import * as S from './styles';
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import CreateWorkspace from '../../../components/Modals/CreateModal/CreateModal';
+import axios from 'axios';
 
 export default function WorkspaceDefault() {
   const [isOpenModal, setOpenModal] = useState<boolean>(false);
   const user = useRecoilValue(userSelector);
   const navigate = useNavigate();
+  const [workspaces, setWorkspaces] = useState<any>();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const handleModal = useCallback(() => {
     setOpenModal(!isOpenModal);
   }, [isOpenModal]);
+
+  useEffect(() => {
+    const fetchWorkspaces = async () => {
+      try {
+        setError(null);
+        setWorkspaces(null);
+        setLoading(true);
+
+        const response = await axios.get('/workspace');
+        if (response.status === 200) {
+          setWorkspaces(response.data);
+        }
+      } catch (error: any) {
+        setError(error);
+      }
+      setLoading(false);
+    };
+
+    fetchWorkspaces();
+  }, []);
+
+  if (loading) return <div>로딩중..</div>;
+  if (error) return <div>에러가 발생했습니다</div>;
+  if (!workspaces) return null;
 
   return (
     <S.Container>
@@ -63,33 +91,26 @@ export default function WorkspaceDefault() {
         </S.Wrapper>
 
         <Grid container spacing={2}>
-          <Grid item xs={12} sm={4} md={3}>
-            <S.Item
-              onClick={() => {
-                navigate('/workspace-detail');
-              }}
-            >
-              <S.GradientBG></S.GradientBG>
-              <S.ItemContents>
-                <S.Title>MOKA</S.Title>
-                <S.ItemBoardName>First Board</S.ItemBoardName>
-                <S.ProfileImages>
-                  <ProfileImg image="/assets/workspace/sample-profile-image.png" />
-                  <ProfileImg image="/assets/workspace/sample-profile-image.png" />
-                  <ProfileImg image="/assets/workspace/sample-profile-image.png" />
-                </S.ProfileImages>
-              </S.ItemContents>
-            </S.Item>
-          </Grid>
-          <Grid item xs={12} sm={4} md={3}>
-            <S.Item></S.Item>
-          </Grid>
-          <Grid item xs={12} sm={4} md={3}>
-            <S.Item></S.Item>
-          </Grid>
-          <Grid item xs={12} sm={4} md={3}>
-            <S.Item></S.Item>
-          </Grid>
+          {workspaces.map((workspace: any) => (
+            <Grid item xs={12} sm={4} md={3} key={workspace.id}>
+              <S.Item
+                onClick={() => {
+                  navigate('/workspace-detail');
+                }}
+              >
+                <S.GradientBG></S.GradientBG>
+                <S.ItemContents>
+                  <S.Title>{workspace.name}</S.Title>
+                  <S.ItemBoardName>{workspace.summary}</S.ItemBoardName>
+                  <S.ProfileImages>
+                    <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+                    <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+                    <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+                  </S.ProfileImages>
+                </S.ItemContents>
+              </S.Item>
+            </Grid>
+          ))}
         </Grid>
       </S.ContentsWrapper>
     </S.Container>

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -34,7 +34,8 @@ export default function WorkspaceDefault() {
   const [isOpenModal, setOpenModal] = useState<boolean>(false);
   const user = useRecoilValue(userSelector);
   const navigate = useNavigate();
-  const [workspaces, setWorkspaces] = useState<any>();
+  const [cWorkspaces, setCWorkspaces] = useState<any>();
+  const [pWorkspaces, setPWorkspaces] = useState<any>();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
@@ -49,12 +50,18 @@ export default function WorkspaceDefault() {
   const fetchWorkspaces = async () => {
     try {
       setError(null);
-      setWorkspaces(null);
+      setCWorkspaces(null);
+      setPWorkspaces(null);
       setLoading(true);
 
       const response = await axios.get('/workspace/list');
       if (response.status === 200) {
-        setWorkspaces(response.data);
+        setCWorkspaces(response.data);
+      }
+
+      const response2 = await axios.get('/workspace/list/participate');
+      if (response2.status === 200) {
+        setPWorkspaces(response.data);
       }
     } catch (error: any) {
       setError(error);
@@ -68,7 +75,7 @@ export default function WorkspaceDefault() {
 
   if (loading) return <div>로딩중..</div>;
   if (error) return <div>에러가 발생했습니다</div>;
-  if (!workspaces) return null;
+  if (!pWorkspaces && !cWorkspaces) return null;
 
   return (
     <S.Container>
@@ -114,8 +121,26 @@ export default function WorkspaceDefault() {
           </Default>
         </S.Wrapper>
 
+        <S.SubTitle>생성한 워크스페이스</S.SubTitle>
         <Grid container spacing={2}>
-          {workspaces.map((workspace: any) => (
+          {cWorkspaces.map((workspace: any) => (
+            <Grid item xs={12} sm={6} md={4} lg={3} key={workspace.id}>
+              <S.Item onClick={handleNavigate}>
+                <S.GradientBG></S.GradientBG>
+                <S.ItemContents>
+                  <S.Title>{workspace.name}</S.Title>
+                  <S.ItemBoardName>{workspace.summary}</S.ItemBoardName>
+                  <S.ProfileImages>
+                    <UserImages members={workspace.memberInfo}></UserImages>
+                  </S.ProfileImages>
+                </S.ItemContents>
+              </S.Item>
+            </Grid>
+          ))}
+        </Grid>
+        <S.SubTitle>참여한 워크스페이스</S.SubTitle>
+        <Grid container spacing={2}>
+          {pWorkspaces.map((workspace: any) => (
             <Grid item xs={12} sm={6} md={4} lg={3} key={workspace.id}>
               <S.Item onClick={handleNavigate}>
                 <S.GradientBG></S.GradientBG>

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -13,6 +13,23 @@ import { useState, useCallback, useEffect } from 'react';
 import CreateWorkspace from '../../../components/Modals/CreateModal/CreateModal';
 import axios from 'axios';
 
+function UserImages(props: any) {
+  console.log(props.members);
+  if (props.members.length > 3)
+    return (
+      <>
+        <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+        <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+        <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+      </>
+    );
+  props.members.map(() => {
+    return <ProfileImg image="/assets/workspace/sample-profile-image.png" />;
+  });
+
+  return <></>;
+}
+
 export default function WorkspaceDefault() {
   const [isOpenModal, setOpenModal] = useState<boolean>(false);
   const user = useRecoilValue(userSelector);
@@ -35,7 +52,7 @@ export default function WorkspaceDefault() {
       setWorkspaces(null);
       setLoading(true);
 
-      const response = await axios.get('/workspace');
+      const response = await axios.get('/workspace/list');
       if (response.status === 200) {
         setWorkspaces(response.data);
       }
@@ -43,6 +60,10 @@ export default function WorkspaceDefault() {
       setError(error);
     }
     setLoading(false);
+  };
+
+  const handleNavigate = () => {
+    navigate('/workspace-detail');
   };
 
   if (loading) return <div>로딩중..</div>;
@@ -95,20 +116,14 @@ export default function WorkspaceDefault() {
 
         <Grid container spacing={2}>
           {workspaces.map((workspace: any) => (
-            <Grid item xs={12} sm={4} md={3} key={workspace.id}>
-              <S.Item
-                onClick={() => {
-                  navigate('/workspace-detail');
-                }}
-              >
+            <Grid item xs={12} sm={6} md={4} lg={3} key={workspace.id}>
+              <S.Item onClick={handleNavigate}>
                 <S.GradientBG></S.GradientBG>
                 <S.ItemContents>
                   <S.Title>{workspace.name}</S.Title>
                   <S.ItemBoardName>{workspace.summary}</S.ItemBoardName>
                   <S.ProfileImages>
-                    <ProfileImg image="/assets/workspace/sample-profile-image.png" />
-                    <ProfileImg image="/assets/workspace/sample-profile-image.png" />
-                    <ProfileImg image="/assets/workspace/sample-profile-image.png" />
+                    <UserImages members={workspace.memberInfo}></UserImages>
                   </S.ProfileImages>
                 </S.ItemContents>
               </S.Item>

--- a/src/pages/workspace/default/styles.ts
+++ b/src/pages/workspace/default/styles.ts
@@ -68,6 +68,8 @@ export const ItemBoardName = styled.h1`
 export const ProfileImages = styled.div`
   display: flex;
   justify-content: flex-start;
+  text-align: center;
+  align-items: center;
 `;
 export const ProfileImage = styled.div`
   width: 40px;

--- a/src/pages/workspace/default/styles.ts
+++ b/src/pages/workspace/default/styles.ts
@@ -24,6 +24,12 @@ export const Title = styled.h1`
   font-family: 'LINESeedKR-Bd';
   color: #4f4e4e;
 `;
+
+export const SubTitle = styled(Title)`
+  font-size: 18px;
+  font-weight: 400;
+`;
+
 export const CreateButton = styled.button`
   font-family: 'LINESeedKR-Rg';
   background-color: #fca4be;

--- a/src/utils/dbconfig.ts
+++ b/src/utils/dbconfig.ts
@@ -21,7 +21,7 @@ export const DBConfig = {
         {
           name: 'memberInfo',
           keypath: 'memberInfo',
-          options: { unique: true },
+          options: { unique: false },
         },
       ],
     },


### PR DESCRIPTION
## 워크스페이스 조회 모킹 API 생성 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
<!-- PIM-xxxx -->
PIM-79

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링
- [ ] UI 구현 및 변경

### 구현 내용
워크스페이스 조회 모킹 API 생성

### 리뷰 포인트
워크스페이스 생성 시 워크스페이스 페이지에 잘 뜨는지 확인해주세요!
**현재 로그인한 사용자는 'test@gmail.com'으로 고정**
1. 직접 생성한 워크스페이스 
2. 다른 사람이 생성했지만, 초대 이메일을 받은 경우 
위의 경우에는 현재 owner가 'test@gmail.com'으로 고정되어 있기 때문에 이 부분을 바꾸고 테스트하면 됩니다!
'test@gmail.com' -> 'test2@gmail.com' / 그리고 초대 사용자에 'test@gmail.com' 
<img width="523" alt="image" src="https://user-images.githubusercontent.com/63833392/216220882-ec32de0a-40da-4622-aa95-723476a26153.png">


### TODO
- [ ] Loading, Error 페이지 UI
- [ ] recoil-persistence 적용
