### PR TITLE
[PIM-86] 카드 내 아이템 CRUD API 구현

### DIFF
--- a/src/mocks/Board/cardHandlers.ts
+++ b/src/mocks/Board/cardHandlers.ts
@@ -1,11 +1,11 @@
 import { rest } from 'msw';
-import memberList from './data/getMemberData.json';
+import memberList from '../data/getMemberData.json';
 import { useIndexedDB } from 'react-indexed-db';
 
 const { getAll, add, deleteRecord, update, getByID, getByIndex } =
   useIndexedDB('card');
 
-export const dataHandlers = [
+export const cardHandlers = [
   rest.get('/members/list', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(memberList));
   }),
@@ -35,7 +35,11 @@ export const dataHandlers = [
   rest.post('/card/update-title', async (req: any, res, ctx) => {
     try {
       const target = await getByID(req.body.cardId);
-      update({ title: req.body.title, id: target.id, order: target.order });
+      update({
+        title: req.body.title,
+        id: target.id,
+        order: target.order,
+      });
       return res(ctx.status(200));
     } catch {
       return res(ctx.status(500), ctx.json({ message: 'Fail to Update Data' }));

--- a/src/mocks/Board/itemHandlers.ts
+++ b/src/mocks/Board/itemHandlers.ts
@@ -1,0 +1,34 @@
+import { rest } from 'msw';
+import { useIndexedDB } from 'react-indexed-db';
+const { getAll, add, deleteRecord, getByIndex } = useIndexedDB('item');
+
+export const itemHandlers = [
+  rest.get('/list/item/:cardId', async (req, res, ctx) => {
+    const AllList = await getAll();
+    const itemList = AllList.filter(
+      (list: any) => list.cardId == req.params.cardId,
+    );
+    return res(ctx.status(200), ctx.json(itemList));
+  }),
+  rest.post('/item/create', async (req: any, res, ctx) => {
+    add(req.body);
+    const AllList = await getAll();
+    const targetList = AllList.filter(
+      (list) => list.cardId === req.body.cardId,
+    );
+    return res(ctx.status(200), ctx.json(targetList));
+  }),
+
+  rest.post('/item/clear', async (req: any, res, ctx) => {
+    const AllList = await getAll();
+    const target = await getByIndex('cardId', req.body.cardId);
+
+    AllList.map((list) => {
+      if (list.cardId == target.cardId) {
+        deleteRecord(list.id);
+      }
+    });
+
+    return res(ctx.status(200), ctx.json(AllList));
+  }),
+];

--- a/src/mocks/Board/itemHandlers.ts
+++ b/src/mocks/Board/itemHandlers.ts
@@ -1,6 +1,7 @@
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
-const { getAll, add, deleteRecord, getByIndex } = useIndexedDB('item');
+const { getAll, add, deleteRecord, getByIndex, getByID, update } =
+  useIndexedDB('item');
 
 export const itemHandlers = [
   rest.get('/list/item/:cardId', async (req, res, ctx) => {
@@ -30,5 +31,18 @@ export const itemHandlers = [
     });
 
     return res(ctx.status(200), ctx.json(AllList));
+  }),
+
+  rest.post('/item/update-card-index', async (req: any, res, ctx) => {
+    const target = await getByID(req.body.id);
+
+    update({
+      title: target.title,
+      id: target.id,
+      order: target.order,
+      cardId: req.body.newIndex,
+    });
+
+    return res(ctx.status(200));
   }),
 ];

--- a/src/mocks/browsers.ts
+++ b/src/mocks/browsers.ts
@@ -1,10 +1,12 @@
 import { setupWorker } from 'msw';
-import { dataHandlers } from './boardHandlers';
+import { cardHandlers } from './Board/CardHandlers';
 import { handlers } from './handlers';
 import { workspaceHandlers } from './workspaceHandlers';
+import { itemHandlers } from './Board/itemHandlers';
 
 export const worker = setupWorker(
   ...handlers,
-  ...dataHandlers,
   ...workspaceHandlers,
+  ...cardHandlers,
+  ...itemHandlers,
 );

--- a/src/pages/board/Card/Card.tsx
+++ b/src/pages/board/Card/Card.tsx
@@ -1,13 +1,12 @@
 import { Default, Mobile } from '@/utils/mediaQuery';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { ReactSortable } from 'react-sortablejs';
 import DropDownMenu from '../DropDownMenu/dropDownMenu';
-import * as S from '../styles';
 import Item from '../Item/Item';
-import axios from 'axios';
-import { orderBy } from 'cypress/types/lodash';
+import * as S from '../styles';
 
 interface ICardProp {
   title: string;
@@ -29,7 +28,7 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
   const [items, setItems] = useState<IItem[]>([]);
 
   useEffect(() => {
-    axios.get(`/list/item/${cardId}`).then((res) => setItems(res.data));
+    fatchItems();
   }, []);
 
   const handleSubmit = (e: { target: any; preventDefault: () => void }) => {
@@ -69,11 +68,19 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
       .catch((error) => alert(error));
   };
 
+  const fatchItems = () => {
+    axios
+      .get(`/list/item/${cardId}`)
+      .then((res) =>
+        setItems(res.data.sort((a: IItem, b: IItem) => a.order - b.order)),
+      );
+  };
+
   return (
     <div>
       <Default>
-        <S.ListWrapper draggable="true" key={cardId}>
-          <S.ListHeader>
+        <S.ListWrapper key={cardId}>
+          <S.ListHeader draggable="true">
             <input
               defaultValue={title}
               placeholder={'카드 제목을 입력해주세요'}
@@ -104,24 +111,21 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
             setList={setItems}
             list={items}
             onEnd={(e) => {
-              axios
-                .post('/item/update-index', {
-                  id: parseInt(e.item.id),
-                  oldCardIndex: parseInt(e.from.id),
-                  newCardIndex: parseInt(e.to.id),
-                  oldIndex: e.oldIndex,
-                  newIndex: e.newIndex,
-                })
-                .then((res) => setItems(res.data));
+              axios.post('/item/update-index', {
+                id: parseInt(e.item.id),
+                oldCardIndex: parseInt(e.from.id),
+                newCardIndex: parseInt(e.to.id),
+                oldIndex: e.oldIndex,
+                newIndex: e.newIndex,
+              });
             }}
+            onChange={fatchItems}
           >
-            {items
-              .sort((a, b) => a.order - b.order)
-              .map((item: IItem) => (
-                <Item key={item.id} itemId={item.id}>
-                  {item.title}
-                </Item>
-              ))}
+            {items.map((item: IItem) => (
+              <Item key={item.id} itemId={item.id}>
+                {item.title}
+              </Item>
+            ))}
           </ReactSortable>
           {!showForm && (
             <S.AddBtn onClick={() => setShowForm(true)}>

--- a/src/pages/board/Card/Card.tsx
+++ b/src/pages/board/Card/Card.tsx
@@ -1,7 +1,7 @@
 import { Default, Mobile } from '@/utils/mediaQuery';
 import { faEllipsis } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ReactSortable } from 'react-sortablejs';
 import DropDownMenu from '../DropDownMenu/dropDownMenu';
 import * as S from '../styles';
@@ -14,34 +14,47 @@ interface ICardProp {
   UpdateList: () => void;
 }
 
-interface ICard {
+interface IItem {
   id: number;
-  text: string;
+  title: string;
+  order: number;
+  cardId: number;
 }
 
-const List: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
+const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
   const [showForm, setShowForm] = useState<boolean>(false);
   const [showMenu, setShowMenu] = useState<boolean>(false);
   const [text, setText] = useState<string>('');
-  const [cards, setCards] = useState<ICard[]>([]);
+  const [items, setItems] = useState<IItem[]>([]);
+
+  useEffect(() => {
+    axios.get(`/list/item/${cardId}`).then((res) => setItems(res.data));
+  }, []);
 
   const handleSubmit = (e: { target: any; preventDefault: () => void }) => {
     e.preventDefault();
 
     if (text.length !== 0) {
-      const card = {
-        id: cards.length + 1,
-        text,
+      const item = {
+        title: text,
+        order: items.length + 1,
+        cardId,
       };
 
-      setCards([...cards, card]);
+      axios
+        .post('/item/create', {
+          ...item,
+        })
+        .then((res) => setItems(res.data));
+
       setText('');
     }
   };
 
   const handleDeleteItems = () => {
-    setCards([]);
+    setItems([]);
     setShowForm(false);
+    axios.post('/item/clear', { cardId }).then((res) => console.log(res));
   };
 
   const handleCancel = () => {
@@ -86,11 +99,11 @@ const List: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
             delay={1}
             swap
             multiDrag
-            setList={setCards}
-            list={cards}
+            setList={setItems}
+            list={items}
           >
-            {cards.map((card: ICard) => (
-              <Item key={card.id}>{card.text}</Item>
+            {items.map((card: IItem) => (
+              <Item key={card.id}>{card.title}</Item>
             ))}
           </ReactSortable>
           {!showForm && (
@@ -132,11 +145,11 @@ const List: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
             delay={1}
             swap
             multiDrag
-            setList={setCards}
-            list={cards}
+            setList={setItems}
+            list={items}
           >
-            {cards.map((card: ICard) => (
-              <Item key={card.id}>{card.text}</Item>
+            {items.map((card: IItem) => (
+              <Item key={card.id}>{card.title}</Item>
             ))}
           </ReactSortable>
           {!showForm && (
@@ -166,4 +179,4 @@ const List: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
   );
 };
 
-export default List;
+export default Card;

--- a/src/pages/board/Card/Card.tsx
+++ b/src/pages/board/Card/Card.tsx
@@ -71,7 +71,7 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
   return (
     <div>
       <Default>
-        <S.ListWrapper draggable="true">
+        <S.ListWrapper draggable="true" key={cardId}>
           <S.ListHeader>
             <input
               defaultValue={title}
@@ -94,6 +94,7 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
           </S.ListHeader>
           <ReactSortable
             className="itemWrapper"
+            id={`${cardId}`}
             group="shared"
             animation={200}
             delay={1}
@@ -101,9 +102,18 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
             multiDrag
             setList={setItems}
             list={items}
+            onEnd={(e) => {
+              axios.post('/item/update-card-index', {
+                id: parseInt(e.item.id),
+                oldIndex: parseInt(e.from.id),
+                newIndex: parseInt(e.to.id),
+              });
+            }}
           >
-            {items.map((card: IItem) => (
-              <Item key={card.id}>{card.title}</Item>
+            {items.map((item: IItem) => (
+              <Item key={item.id} itemId={item.id}>
+                {item.title}
+              </Item>
             ))}
           </ReactSortable>
           {!showForm && (
@@ -148,8 +158,10 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
             setList={setItems}
             list={items}
           >
-            {items.map((card: IItem) => (
-              <Item key={card.id}>{card.title}</Item>
+            {items.map((item: IItem) => (
+              <Item key={item.id} itemId={item.id}>
+                {item.title}
+              </Item>
             ))}
           </ReactSortable>
           {!showForm && (

--- a/src/pages/board/Card/Card.tsx
+++ b/src/pages/board/Card/Card.tsx
@@ -7,6 +7,7 @@ import DropDownMenu from '../DropDownMenu/dropDownMenu';
 import * as S from '../styles';
 import Item from '../Item/Item';
 import axios from 'axios';
+import { orderBy } from 'cypress/types/lodash';
 
 interface ICardProp {
   title: string;
@@ -37,7 +38,7 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
     if (text.length !== 0) {
       const item = {
         title: text,
-        order: items.length + 1,
+        order: items.length,
         cardId,
       };
 
@@ -103,18 +104,24 @@ const Card: React.FC<ICardProp> = ({ title, cardId, UpdateList }) => {
             setList={setItems}
             list={items}
             onEnd={(e) => {
-              axios.post('/item/update-card-index', {
-                id: parseInt(e.item.id),
-                oldIndex: parseInt(e.from.id),
-                newIndex: parseInt(e.to.id),
-              });
+              axios
+                .post('/item/update-index', {
+                  id: parseInt(e.item.id),
+                  oldCardIndex: parseInt(e.from.id),
+                  newCardIndex: parseInt(e.to.id),
+                  oldIndex: e.oldIndex,
+                  newIndex: e.newIndex,
+                })
+                .then((res) => setItems(res.data));
             }}
           >
-            {items.map((item: IItem) => (
-              <Item key={item.id} itemId={item.id}>
-                {item.title}
-              </Item>
-            ))}
+            {items
+              .sort((a, b) => a.order - b.order)
+              .map((item: IItem) => (
+                <Item key={item.id} itemId={item.id}>
+                  {item.title}
+                </Item>
+              ))}
           </ReactSortable>
           {!showForm && (
             <S.AddBtn onClick={() => setShowForm(true)}>

--- a/src/pages/board/DropDownMenu/dropDownMenu.tsx
+++ b/src/pages/board/DropDownMenu/dropDownMenu.tsx
@@ -49,7 +49,7 @@ const DropDownMenu: React.FC<IDropMenu> = ({
     <S.Container ref={wrapperRef}>
       {visible && (
         <ul>
-          <li onClick={handleDeleteCard}>리스트 삭제</li>
+          <li onClick={handleDeleteCard}>카드 삭제</li>
           <li onClick={handleItemMenu}>아이템 전체 삭제</li>
         </ul>
       )}

--- a/src/pages/board/Item/Item.tsx
+++ b/src/pages/board/Item/Item.tsx
@@ -14,7 +14,7 @@ const Item: React.FC<IItemProps> = ({ children, itemId }) => {
     console.log(isOpen);
   };
   return (
-    <S.ItemContainer id={`${itemId}`}>
+    <S.ItemContainer id={`${itemId}`} draggable="true">
       <S.Item onClick={() => setOpen(true)}>{children}</S.Item>
       {isOpen && <Detail setOpen={handleModal} />}
     </S.ItemContainer>

--- a/src/pages/board/Item/Item.tsx
+++ b/src/pages/board/Item/Item.tsx
@@ -4,16 +4,17 @@ import * as S from '../styles';
 
 interface IItemProps {
   children: React.ReactNode;
+  itemId: number;
 }
 
-const Item: React.FC<IItemProps> = ({ children }) => {
+const Item: React.FC<IItemProps> = ({ children, itemId }) => {
   const [isOpen, setOpen] = useState<boolean>(false);
   const handleModal = () => {
     setOpen(false);
     console.log(isOpen);
   };
   return (
-    <S.ItemContainer>
+    <S.ItemContainer id={`${itemId}`}>
       <S.Item onClick={() => setOpen(true)}>{children}</S.Item>
       {isOpen && <Detail setOpen={handleModal} />}
     </S.ItemContainer>

--- a/src/pages/board/index.tsx
+++ b/src/pages/board/index.tsx
@@ -5,7 +5,7 @@ import { Default, Mobile } from '@/utils/mediaQuery';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import Sortable from 'sortablejs';
-import List from './Card/Card';
+import Card from './Card/Card';
 import * as S from './styles';
 interface ICard {
   id: number;
@@ -80,7 +80,7 @@ export default function Board() {
               {lists
                 .sort((a, b) => a.order - b.order)
                 .map((list: ICard) => (
-                  <List
+                  <Card
                     title={list.title}
                     key={list.id}
                     cardId={list.id}
@@ -98,7 +98,7 @@ export default function Board() {
           <S.MobileRightWrapper>
             <S.ListMobileContiner className="column">
               {lists.map((list: ICard) => (
-                <List
+                <Card
                   title={list.title}
                   key={list.id}
                   cardId={list.id}

--- a/src/pages/board/styles.ts
+++ b/src/pages/board/styles.ts
@@ -87,7 +87,7 @@ export const Item = styled.div`
   background: rgba(252, 164, 190, 0.23);
   border-radius: 10px;
   height: 35px;
-  margin-bottom: 10px;
+  margin-bottom: 15px;
   width: 80%;
   cursor: pointer;
 `;

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -5,13 +5,12 @@ import { SubHeader } from '@/components/SubHeader/SubHeader';
 import { userSelector } from '@/recoil/atom/userSelector';
 import { Default, Mobile } from '@/utils/mediaQuery';
 import Grid from '@mui/material/Grid';
-import { useCallback, useState } from 'react';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-import * as S from './styles';
-import { useState, useCallback, useEffect } from 'react';
 import CreateWorkspace from '../../../components/Modals/CreateModal/CreateModal';
-import axios from 'axios';
+import * as S from './styles';
 
 function UserImages(props: any) {
   console.log(props.members);

--- a/src/utils/dbconfig.ts
+++ b/src/utils/dbconfig.ts
@@ -33,5 +33,14 @@ export const DBConfig = {
         { name: 'order', keypath: 'order' },
       ],
     },
+    {
+      store: 'item',
+      storeConfig: { keyPath: 'id', autoIncrement: true },
+      storeSchema: [
+        { name: 'title', keypath: 'title' },
+        { name: 'order', keypath: 'order' },
+        { name: 'cardId', keypath: 'cardId' },
+      ],
+    },
   ],
 };


### PR DESCRIPTION
## 카드 내 아이템 CRUD API 구현 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
PIM-86
<!-- PIM-xxxx -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 리팩토링
- [ ] UI 구현 및 변경

### 구현 내용
1) 카드 내 아이템의 순서를 변경했을 때
2) 아이템을 다른 카드로 이동했을 때

변경된 순서를 db에 저장합니다. 새로고침 후에도 변경된 순서가 잘 반영되는 지 확인해주세요.


### 리뷰 포인트
순서를 `여기저기 이곳저곳 왔다갔다` 변경하고 새로고침 해보기
<!-- 오류 있는지 함께 확인해주세요 -->

### TODO
- 아이템 상세 페이지 구현 예정입니다.
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
