### PR TITLE
[PIM-87] 워크스페이스 삭제 Mock API 구현 및 Type 지정

### DIFF
--- a/src/components/Modals/CreateModal/CreateModal.tsx
+++ b/src/components/Modals/CreateModal/CreateModal.tsx
@@ -1,19 +1,23 @@
 import Button from '@/components/Button/Button';
 import Modal from '@/components/Modal/Modal';
+import { userSelector } from '@/recoil/atom/userSelector';
+import { CreateWorkspaceProps } from '@/utils/types';
 import Chip from '@mui/material/Chip';
 import Paper from '@mui/material/Paper';
 import { styled } from '@mui/material/styles';
+import axios, { AxiosError } from 'axios';
 import React, { useState } from 'react';
-import * as S from './CreateModal.style';
-import axios from 'axios';
-import { userSelector } from '@/recoil/atom/userSelector';
 import { useRecoilState } from 'recoil';
+import * as S from './CreateModal.style';
 
 const ListItem = styled('li')(({ theme }) => ({
   margin: theme.spacing(0.5),
 }));
 
-export const CreateWorkspace = (props: any) => {
+export const CreateWorkspace = ({
+  setOpenModal,
+  fetchWorkspaces,
+}: CreateWorkspaceProps) => {
   const [user, setUser] = useRecoilState(userSelector);
   const [errorText, setErrorText] = useState<string>('');
   const [name, setName] = useState<string>('');
@@ -23,7 +27,7 @@ export const CreateWorkspace = (props: any) => {
   const [emailList, setEmailList] = useState<string[]>([]);
 
   const handleModal = () => {
-    props.setOpenModal(false);
+    setOpenModal(false);
   };
   const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
@@ -64,11 +68,12 @@ export const CreateWorkspace = (props: any) => {
     try {
       const response = await axios.post('/workspace/create', info);
       if (response.status === 200) {
-        props.setOpenModal(false);
-        props.fetchWorkspaces();
+        setOpenModal(false);
+        fetchWorkspaces();
       }
-    } catch (error: any) {
-      console.log(error);
+    } catch (error) {
+      const err = error as AxiosError;
+      console.log(err.response?.data);
     }
   };
 

--- a/src/components/Modals/DeleteModal/DeleteModal.tsx
+++ b/src/components/Modals/DeleteModal/DeleteModal.tsx
@@ -5,6 +5,7 @@ import SubTitle from '@/components/SubTitle/SubTitle';
 export default function DeleteModal(props: any) {
   const handleModal = () => {
     props.setOpenModal(false);
+    props.deleteWorkspace();
   };
   return (
     <Modal onClickToggleModal={handleModal}>

--- a/src/components/Modals/DeleteModal/DeleteModal.tsx
+++ b/src/components/Modals/DeleteModal/DeleteModal.tsx
@@ -1,11 +1,16 @@
 import Modal from '@/components/Modal/Modal';
 import * as S from './DeleteModal.styles';
 import SubTitle from '@/components/SubTitle/SubTitle';
+import { DeleteWorkspaceProps } from '@/utils/types';
 
-export default function DeleteModal(props: any) {
+export default function DeleteModal({
+  workspaceName,
+  setOpenModal,
+  deleteWorkspace,
+}: DeleteWorkspaceProps) {
   const handleModal = () => {
-    props.setOpenModal(false);
-    props.deleteWorkspace();
+    setOpenModal(false);
+    deleteWorkspace();
   };
   return (
     <Modal onClickToggleModal={handleModal}>
@@ -15,8 +20,7 @@ export default function DeleteModal(props: any) {
         불가능합니다.
       </S.ExplainText>
       <S.ExplainText>
-        워크페이스 삭제를 원하시면 {props.workspaceName}을(를) 아래에
-        입력해주세요.
+        워크페이스 삭제를 원하시면 {workspaceName}을(를) 아래에 입력해주세요.
       </S.ExplainText>
       <S.RoundInput></S.RoundInput>
       <S.EmptyBox />

--- a/src/components/Modals/InviteModal/InviteModal.tsx
+++ b/src/components/Modals/InviteModal/InviteModal.tsx
@@ -1,4 +1,5 @@
 import SubTitle from '@/components/SubTitle/SubTitle';
+import { InviteMembersProps } from '@/utils/types';
 import { useState } from 'react';
 import Modal from '../../Modal/Modal';
 import {
@@ -8,13 +9,13 @@ import {
 } from '../DeleteModal/DeleteModal.styles';
 import * as S from './InviteModal.styles';
 
-export default function InviteModal(props: any) {
+export default function InviteModal({ setOpenModal }: InviteMembersProps) {
   const [email, setEmail] = useState<string>();
   const handleChangeEmail = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
   };
   const handleModal = () => {
-    props.setOpenModal(false);
+    setOpenModal(false);
   };
 
   return (

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { IUser } from '@/utils/types';
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
 
@@ -19,7 +20,11 @@ export const handlers = [
   }),
 
   rest.post('/login', async (req: any, res, ctx) => {
-    let user;
+    let user: IUser = {
+      email: '',
+      password: '',
+    };
+
     await getAll().then((users) => {
       user = users.find(({ email }) => email === req.body.email);
     });

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,4 +1,4 @@
-import { IUser } from '@/utils/types';
+import { IJUser, IUser } from '@/utils/types';
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
 
@@ -19,18 +19,20 @@ export const handlers = [
     );
   }),
 
-  rest.post('/login', async (req: any, res, ctx) => {
+  rest.post('/login', async (req, res, ctx) => {
+    const { email, password } = await req.json<IUser>();
+
     let user: IUser = {
       email: '',
       password: '',
     };
 
     await getAll().then((users) => {
-      user = users.find(({ email }) => email === req.body.email);
+      user = users.find((u) => u.email === email);
     });
 
     if (user) {
-      if (req.body.password === user.password) {
+      if (user.password === password) {
         return res(ctx.status(200), ctx.delay(2000), ctx.json({ user }));
       }
       return res(
@@ -46,11 +48,14 @@ export const handlers = [
     );
   }),
 
-  rest.post('/sign-up', async (req: any, res, ctx) => {
+  rest.post('/sign-up', async (req, res, ctx) => {
+    const { email, password, nickname } = await req.json<IJUser>();
+    console.log(email, password);
+
     let isExist;
+
     await getAll().then((users) => {
-      console.log(users.find(({ email }) => email === req.body.email));
-      users.find(({ email }) => email === req.body.email) !== undefined
+      users.find((u) => u.email === email) !== undefined
         ? (isExist = true)
         : (isExist = false);
     });
@@ -59,7 +64,11 @@ export const handlers = [
       return res(ctx.status(409), ctx.json({ message: 'Registered Email!' }));
     } else {
       try {
-        await add({ ...req.body });
+        await add({
+          email: email,
+          password: password,
+          nickname: nickname,
+        });
         return res(ctx.status(200), ctx.json({ message: 'SignUp Success!' }));
       } catch (error) {
         return res(

--- a/src/mocks/workspaceHandlers.ts
+++ b/src/mocks/workspaceHandlers.ts
@@ -1,14 +1,8 @@
+import { IWorkspace } from '@/utils/types';
 import { getAllByAltText } from '@testing-library/react';
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
 const { getAll, add, deleteRecord } = useIndexedDB('workspace');
-
-type IWorkspace = {
-  owner: string;
-  name: string;
-  summary: string;
-  memberInfo: string[];
-};
 
 export const workspaceHandlers = [
   rest.post('/workspace/create', async (req: any, res, ctx) => {

--- a/src/mocks/workspaceHandlers.ts
+++ b/src/mocks/workspaceHandlers.ts
@@ -1,7 +1,7 @@
 import { getAllByAltText } from '@testing-library/react';
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
-const { getAll, add } = useIndexedDB('workspace');
+const { getAll, add, deleteRecord } = useIndexedDB('workspace');
 
 type IWorkspace = {
   owner: string;
@@ -49,5 +49,18 @@ export const workspaceHandlers = [
     });
 
     return res(ctx.status(200), ctx.delay(1000), ctx.json(PWorkspaces));
+  }),
+
+  rest.post('/workspace/delete', async (req: any, res, ctx) => {
+    try {
+      await deleteRecord(req.body.workspaceId);
+
+      return res(
+        ctx.status(200),
+        ctx.json({ message: 'Workspace Delete Success!' }),
+      );
+    } catch {
+      return res(ctx.status(500), ctx.json({ message: 'Fail to Delete Data' }));
+    }
   }),
 ];

--- a/src/mocks/workspaceHandlers.ts
+++ b/src/mocks/workspaceHandlers.ts
@@ -1,13 +1,20 @@
-import { IWorkspace } from '@/utils/types';
+import { IDeleteWorkspace, IUser, IWorkspace } from '@/utils/types';
 import { getAllByAltText } from '@testing-library/react';
 import { rest } from 'msw';
 import { useIndexedDB } from 'react-indexed-db';
 const { getAll, add, deleteRecord } = useIndexedDB('workspace');
 
 export const workspaceHandlers = [
-  rest.post('/workspace/create', async (req: any, res, ctx) => {
+  rest.post('/workspace/create', async (req, res, ctx) => {
+    const { owner, name, summary, memberInfo } = await req.json<IWorkspace>();
+
     try {
-      await add({ ...req.body });
+      await add({
+        owner: owner,
+        name: name,
+        summary: summary,
+        memberInfo: memberInfo,
+      });
       return res(
         ctx.status(200),
         ctx.json({ message: 'Workspace Creation Success!' }),
@@ -28,26 +35,31 @@ export const workspaceHandlers = [
     return res(ctx.status(200), ctx.delay(1000), ctx.json(CWorkspaces));
   }),
 
-  rest.get('/workspace/list/participate', async (req: any, res, ctx) => {
+  rest.get('/workspace/list/participate', async (req, res, ctx) => {
     let PWorkspaces: IWorkspace[] = [];
     const email = req.url.searchParams.get('email');
 
-    await getAll().then((workspaces: IWorkspace[]) => {
-      {
-        workspaces.map((workspace) =>
-          workspace.memberInfo.includes(email)
-            ? (PWorkspaces = [...PWorkspaces, workspace])
-            : (PWorkspaces = PWorkspaces),
-        );
-      }
-    });
+    if (email) {
+      await getAll().then((workspaces: IWorkspace[]) => {
+        {
+          workspaces.map((workspace) =>
+            workspace.memberInfo.includes(email)
+              ? (PWorkspaces = [...PWorkspaces, workspace])
+              : (PWorkspaces = PWorkspaces),
+          );
+        }
+      });
+    }
 
     return res(ctx.status(200), ctx.delay(1000), ctx.json(PWorkspaces));
   }),
 
-  rest.post('/workspace/delete', async (req: any, res, ctx) => {
+  rest.post('/workspace/delete', async (req, res, ctx) => {
+    const { workspaceId } = await req.json<IDeleteWorkspace>();
+    console.log(workspaceId);
+
     try {
-      await deleteRecord(req.body.workspaceId);
+      await deleteRecord(workspaceId);
 
       return res(
         ctx.status(200),

--- a/src/pages/authorization/login/index.tsx
+++ b/src/pages/authorization/login/index.tsx
@@ -4,7 +4,7 @@ import { userSelector } from '@/recoil/atom/userSelector';
 import ROUTES from '@/routes';
 import { Default } from '@/utils/mediaQuery';
 import { CircularProgress } from '@mui/material';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { FormEvent, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
@@ -51,13 +51,15 @@ function Login() {
         handleModal();
         setTimeout(() => navigate(ROUTES.MAIN), 1000);
       }
-    } catch (error: any) {
-      if (error.response.status === 400) {
+    } catch (error) {
+      const err = error as AxiosError;
+
+      if (err.response?.status === 400) {
         setLoading(false);
         setModalText('가입된 이메일이 아닙니다. 먼저 가입해 주세요! ✋');
         handleModal();
       }
-      if (error.response.status === 401) {
+      if (err.response?.status === 401) {
         setLoading(false);
         setModalText('비밀번호가 틀렸습니다. 다시 시도해주세요! 😂');
         handleModal();

--- a/src/pages/authorization/sign-up/index.tsx
+++ b/src/pages/authorization/sign-up/index.tsx
@@ -3,7 +3,7 @@ import ROUTES from '@/routes';
 import { emailRegex } from '@/utils/checkEmail';
 import { pwdRegex } from '@/utils/checkPassword';
 import { Default } from '@/utils/mediaQuery';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -52,14 +52,16 @@ export default function SignUp() {
         handleModal();
         setTimeout(() => navigate(ROUTES.LOGIN), 1000);
       }
-    } catch (error: any) {
-      if (error.response.status === 409) {
-        console.log(error.response.data.message);
+    } catch (error) {
+      const err = error as AxiosError;
+
+      if (err.response?.status === 409) {
+        console.log(err.response?.data);
         setModalText('중복된 이메일입니다! 다른 이메일로 가입해 주세요! ✋');
         handleModal();
       }
-      if (error.response.status === 500) {
-        console.log(error.response.data.message);
+      if (err.response?.status === 500) {
+        console.log(err.response?.data);
         setModalText('오류가 발생했습니다. 다시 시도해 주세요!');
         handleModal();
       }

--- a/src/pages/board/ItemModal/detail.tsx
+++ b/src/pages/board/ItemModal/detail.tsx
@@ -1,4 +1,5 @@
 import Modal from '@/components/Modal/Modal';
+import { DetailProps } from '@/utils/types';
 import Box from '@mui/joy/Box';
 import {
   Chip,
@@ -16,7 +17,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { useState } from 'react';
 import * as S from './styles';
 
-export const Detail = ({ setOpen }: any) => {
+export const Detail = ({ setOpen }: DetailProps) => {
   const [value, setValue] = useState<Dayjs | null>(dayjs(new Date()));
   const [personName, setPersonName] = useState<string[]>([]);
   const ITEM_HEIGHT = 48;

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -5,6 +5,11 @@ import { SubHeader } from '@/components/SubHeader/SubHeader';
 import Inform from '@/pages/util';
 import { userSelector } from '@/recoil/atom/userSelector';
 import { Default, Mobile } from '@/utils/mediaQuery';
+import {
+  IWorkspace,
+  WorkspaceContainerProps,
+  WorkspaceUserImageProps,
+} from '@/utils/types';
 import Grid from '@mui/material/Grid';
 import axios, { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
@@ -14,10 +19,10 @@ import CreateWorkspace from '../../../components/Modals/CreateModal/CreateModal'
 import WorkSpaceSkeleton from '../skeleton';
 import * as S from './styles';
 
-function UserImages(props: any) {
-  const remain = props.members.length - 2;
+function UserImages({ members }: WorkspaceUserImageProps) {
+  const remain = members.length - 2;
 
-  if (props.members.length > 3)
+  if (members.length > 3)
     return (
       <S.ProfileImages>
         <ProfileImg image="/assets/workspace/sample-profile-image.png" />
@@ -29,7 +34,7 @@ function UserImages(props: any) {
 
   return (
     <S.ProfileImages>
-      {props.members.map((member: string, index: number) => (
+      {members.map((member: string, index: number) => (
         <ProfileImg
           key={index}
           image="/assets/workspace/sample-profile-image.png"
@@ -39,7 +44,7 @@ function UserImages(props: any) {
   );
 }
 
-function WorkSpaceContainer(props: any) {
+function WorkSpaceContainer({ workspaces }: WorkspaceContainerProps) {
   const navigate = useNavigate();
 
   const handleNavigate = () => {
@@ -48,8 +53,15 @@ function WorkSpaceContainer(props: any) {
 
   return (
     <Grid container spacing={2}>
-      {props.workspaces.map((workspace: any) => (
-        <Grid item xs={12} sm={6} md={4} lg={3} key={workspace.id}>
+      {workspaces?.map((workspace: IWorkspace) => (
+        <Grid
+          item
+          xs={12}
+          sm={6}
+          md={4}
+          lg={3}
+          key={workspace.owner + workspace.name}
+        >
           <S.Item onClick={handleNavigate}>
             <S.GradientBG></S.GradientBG>
             <S.ItemContents>
@@ -67,9 +79,9 @@ function WorkSpaceContainer(props: any) {
 export default function WorkspaceDefault() {
   const [isOpenModal, setOpenModal] = useState<boolean>(false);
   const user = useRecoilValue(userSelector);
-  const [cWorkspaces, setCWorkspaces] = useState<any>();
-  const [pWorkspaces, setPWorkspaces] = useState<any>();
-  const [loading, setLoading] = useState(false);
+  const [cWorkspaces, setCWorkspaces] = useState<IWorkspace[]>();
+  const [pWorkspaces, setPWorkspaces] = useState<IWorkspace[]>();
+  const [loading, setLoading] = useState<Boolean>(false);
   const [error, setError] = useState<Boolean>(false);
 
   const handleModal = () => {
@@ -83,8 +95,8 @@ export default function WorkspaceDefault() {
   const fetchWorkspaces = async () => {
     try {
       setError(false);
-      setCWorkspaces(null);
-      setPWorkspaces(null);
+      setCWorkspaces([]);
+      setPWorkspaces([]);
       setLoading(true);
 
       const response = await axios.get('/workspace/list', {
@@ -162,14 +174,16 @@ export default function WorkspaceDefault() {
             </Button>
           </Default>
         </S.Wrapper>
-        <div hidden={!(cWorkspaces.length || pWorkspaces.length)}>
+        <div hidden={!(cWorkspaces?.length || pWorkspaces?.length)}>
           <S.SubTitle>생성한 워크스페이스</S.SubTitle>
           <WorkSpaceContainer workspaces={cWorkspaces}></WorkSpaceContainer>
-          <S.BlankDiv hidden={cWorkspaces.length}></S.BlankDiv>
+          <S.BlankDiv hidden={cWorkspaces?.length != 0}></S.BlankDiv>
           <S.SubTitle>참여한 워크스페이스</S.SubTitle>
           <WorkSpaceContainer workspaces={pWorkspaces}></WorkSpaceContainer>
         </div>
-        <S.messageDiv hidden={cWorkspaces.length || pWorkspaces.length}>
+        <S.messageDiv
+          hidden={cWorkspaces?.length != 0 || pWorkspaces?.length != 0}
+        >
           <div>
             <h1>워크스페이스가 없습니다!</h1>
             <h1>워크스페이스 생성 또는 참여해보세요 ✋</h1>

--- a/src/pages/workspace/default/index.tsx
+++ b/src/pages/workspace/default/index.tsx
@@ -6,7 +6,7 @@ import Inform from '@/pages/util';
 import { userSelector } from '@/recoil/atom/userSelector';
 import { Default, Mobile } from '@/utils/mediaQuery';
 import Grid from '@mui/material/Grid';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
@@ -67,11 +67,10 @@ function WorkSpaceContainer(props: any) {
 export default function WorkspaceDefault() {
   const [isOpenModal, setOpenModal] = useState<boolean>(false);
   const user = useRecoilValue(userSelector);
-  const navigate = useNavigate();
   const [cWorkspaces, setCWorkspaces] = useState<any>();
   const [pWorkspaces, setPWorkspaces] = useState<any>();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<Boolean>(false);
 
   const handleModal = () => {
     setOpenModal(!isOpenModal);
@@ -83,7 +82,7 @@ export default function WorkspaceDefault() {
 
   const fetchWorkspaces = async () => {
     try {
-      setError(null);
+      setError(false);
       setCWorkspaces(null);
       setPWorkspaces(null);
       setLoading(true);
@@ -106,8 +105,9 @@ export default function WorkspaceDefault() {
       if (response2.status === 200) {
         setPWorkspaces(response2.data);
       }
-    } catch (error: any) {
-      setError(error);
+    } catch (error) {
+      const err = error as AxiosError;
+      setError(true);
     }
     setLoading(false);
   };

--- a/src/pages/workspace/setting/index.tsx
+++ b/src/pages/workspace/setting/index.tsx
@@ -8,6 +8,7 @@ import WorkspaceImg from '@/components/WorkspaceImg/WorkspaceImg';
 import { Default, Mobile } from '@/utils/mediaQuery';
 import React, { useState } from 'react';
 import * as S from './styles';
+import axios from 'axios';
 
 interface IMember {
   name: string;
@@ -91,12 +92,29 @@ export default function WorkspaceSetting() {
   function handleModal() {
     setOpenModal(true);
   }
+
+  const deleteWorkspace = async () => {
+    const workspaceId = 5;
+    try {
+      const response = await axios.post('/workspace/delete', {
+        workspaceId,
+      });
+
+      if (response.status === 200) {
+        // reload
+      }
+    } catch (error: any) {
+      // error 처리
+    }
+  };
+
   return (
     <S.Container>
       {isOpenModal && (
         <DeleteModal
           workspaceName={workspaceName}
           setOpenModal={setOpenModal}
+          deleteWorkspace={deleteWorkspace}
         />
       )}
       <Default>
@@ -123,14 +141,14 @@ export default function WorkspaceSetting() {
               <S.EmptyBox />
               <SubTitle size="sm">이름</SubTitle>
               <S.RoundLineInput
-                defaultValue={workspaceName}
+                // defaultValue={workspaceName}
                 value={changedWorkspaceName}
                 onChange={handleWorkspaceName}
               />
               <S.EmptyBox />
               <SubTitle size="sm">설명</SubTitle>
               <S.RoundLineInput
-                defaultValue={workspaceExplain}
+                // defaultValue={workspaceExplain}
                 value={workspaceExplain}
                 onChange={handleWorkspaceExplain}
               />

--- a/src/pages/workspace/setting/index.tsx
+++ b/src/pages/workspace/setting/index.tsx
@@ -94,11 +94,11 @@ export default function WorkspaceSetting() {
   }
 
   const deleteWorkspace = async () => {
-    const workspaceId = 5;
+    const data = {
+      workspaceId: 1,
+    };
     try {
-      const response = await axios.post('/workspace/delete', {
-        workspaceId,
-      });
+      const response = await axios.post('/workspace/delete', data);
 
       if (response.status === 200) {
         // reload

--- a/src/pages/workspace/setting/index.tsx
+++ b/src/pages/workspace/setting/index.tsx
@@ -8,7 +8,7 @@ import WorkspaceImg from '@/components/WorkspaceImg/WorkspaceImg';
 import { Default, Mobile } from '@/utils/mediaQuery';
 import React, { useState } from 'react';
 import * as S from './styles';
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
 
 interface IMember {
   name: string;
@@ -103,7 +103,8 @@ export default function WorkspaceSetting() {
       if (response.status === 200) {
         // reload
       }
-    } catch (error: any) {
+    } catch (error) {
+      const err = error as AxiosError;
       // error 처리
     }
   };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -24,6 +24,16 @@ export interface UserImaegsProps extends HTMLAttributes<HTMLDivElement> {
   setOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
+export interface WorkspaceUserImageProps
+  extends HTMLAttributes<HTMLDivElement> {
+  members: string[];
+}
+
+export interface WorkspaceContainerProps
+  extends HTMLAttributes<HTMLDivElement> {
+  workspaces?: IWorkspace[];
+}
+
 export interface IWorkspace {
   owner: string;
   name: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -45,3 +45,13 @@ export interface IUser {
   email: string;
   password: string;
 }
+
+export interface IJUser {
+  email: string;
+  password: string;
+  nickname: string;
+}
+
+export interface IDeleteWorkspace {
+  workspaceId: number;
+}

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,37 @@
+import { HTMLAttributes } from 'react';
+
+export interface CreateWorkspaceProps extends HTMLAttributes<HTMLDivElement> {
+  setOpenModal: React.Dispatch<React.SetStateAction<boolean>>;
+  fetchWorkspaces: () => void;
+}
+
+export interface DeleteWorkspaceProps extends HTMLAttributes<HTMLDivElement> {
+  workspaceName: string;
+  setOpenModal: React.Dispatch<React.SetStateAction<boolean>>;
+  deleteWorkspace: () => void;
+}
+
+export interface InviteMembersProps extends HTMLAttributes<HTMLDivElement> {
+  setOpenModal: React.Dispatch<React.SetStateAction<boolean>>;
+  deleteWorkspace: () => void;
+}
+
+export interface DetailProps extends HTMLAttributes<HTMLDivElement> {
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export interface UserImaegsProps extends HTMLAttributes<HTMLDivElement> {
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export interface IWorkspace {
+  owner: string;
+  name: string;
+  summary: string;
+  memberInfo: string[];
+}
+
+export interface IUser {
+  email: string;
+  password: string;
+}


### PR DESCRIPTION
## 워크스페이스 삭제 Mock API 구현 및 Type 지정 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
PIM-87

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리팩토링
- [ ] UI 구현 및 변경

### 구현 내용
- 워크스페이스 삭제 Mock API 구현
- Type 지정

### 리뷰 포인트
**워크스페이스 삭제 Mock API 구현**
1. `pages/workspace/setting/index` 부분에서 workspaceId를 현재 indexed-db에 존재하는 아이디 값으로 변경
2. 삭제 확인
<img width="546" alt="스크린샷 2023-02-06 오후 1 33 28" src="https://user-images.githubusercontent.com/63833392/216884382-43afaf76-e6af-4dc4-bf3e-ae06c1a471a3.png">

### TODO
- [ ] 특정 워크스페이스와 연결

