### PR TITLE
[PIM-91] 라우팅 설정 및 모달 포탈 리팩토링

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,3 +1,5 @@
+import ROUTES from '@/routes';
+import { Link } from 'react-router-dom';
 import Button from '../Button/Button';
 import * as S from './Header.styles';
 import { HeaderProps } from './Header.types';
@@ -12,9 +14,9 @@ export const Header = ({
 }: HeaderProps) => (
   <header>
     <S.HeaderContainer color={color} backgroundColor={backgroundColor}>
-      <div>
+      <Link to={ROUTES.MAIN}>
         <h1>PRELLO</h1>
-      </div>
+      </Link>
       <div>
         {user?.nickname !== '' ? (
           <div>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import { PropsWithChildren } from 'react';
 import * as S from './Modal.style';
 import { ModalProps } from './Modal.types';
+import ModalPortal from './ModalPortal';
 
 function Modal({
   onClickToggleModal,
@@ -12,15 +13,17 @@ function Modal({
     onClickToggleModal?.();
   }
   return (
-    <S.ModalContainer>
-      <S.DialogBox size={size}>
-        <S.CloseButton onClick={handleClick} size={size}>
-          ✖
-        </S.CloseButton>
-        {children}
-      </S.DialogBox>
-      <S.Backdrop onClick={handleClick} />
-    </S.ModalContainer>
+    <ModalPortal>
+      <S.ModalContainer>
+        <S.DialogBox size={size}>
+          <S.CloseButton onClick={handleClick} size={size}>
+            ✖
+          </S.CloseButton>
+          {children}
+        </S.DialogBox>
+        <S.Backdrop onClick={handleClick} />
+      </S.ModalContainer>
+    </ModalPortal>
   );
 }
 

--- a/src/components/Modal/ModalPortal.ts
+++ b/src/components/Modal/ModalPortal.ts
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import ReactDOM from 'react-dom';
+
+interface Props {
+  children: ReactNode;
+}
+const ModalPortal = ({ children }: Props) => {
+  const el = document.getElementById('modal-root') as HTMLElement;
+
+  return ReactDOM.createPortal(children, el);
+};
+
+export default ModalPortal;

--- a/src/components/SubHeader/SubHeader.tsx
+++ b/src/components/SubHeader/SubHeader.tsx
@@ -1,3 +1,5 @@
+import ROUTES from '@/routes';
+import { Link } from 'react-router-dom';
 import * as S from './SubHeader.style';
 import { SubHeaderProps } from './SubHeader.types';
 export const SubHeader = ({
@@ -9,7 +11,9 @@ export const SubHeader = ({
   return (
     <S.Header>
       <S.LeftHeaderDiv>
-        <S.Title>Prello</S.Title>
+        <Link to={ROUTES.MAIN}>
+          <S.Title>Prello</S.Title>
+        </Link>
         {divider && <S.Divider />}
         <S.BoardName>{children}</S.BoardName>
       </S.LeftHeaderDiv>

--- a/src/components/SubHeader/SubHeader.tsx
+++ b/src/components/SubHeader/SubHeader.tsx
@@ -1,5 +1,10 @@
+import { userSelector } from '@/recoil/atom/userSelector';
 import ROUTES from '@/routes';
-import { Link } from 'react-router-dom';
+import { Logout, PersonAdd, Settings } from '@mui/icons-material';
+import { Avatar, Divider, ListItemIcon, Menu, MenuItem } from '@mui/material';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 import * as S from './SubHeader.style';
 import { SubHeaderProps } from './SubHeader.types';
 export const SubHeader = ({
@@ -8,6 +13,28 @@ export const SubHeader = ({
   divider,
   children,
 }: SubHeaderProps) => {
+  const [user, setUser] = useRecoilState(userSelector);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const navigate = useNavigate();
+
+  const handleLogout = () => {
+    handleClose();
+    setUser({
+      id: 0,
+      email: '',
+      password: '',
+      nickname: '',
+    });
+    navigate(ROUTES.MAIN);
+  };
+
+  const handleClick = (event: React.MouseEvent<HTMLImageElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
   return (
     <S.Header>
       <S.LeftHeaderDiv>
@@ -19,7 +46,62 @@ export const SubHeader = ({
       </S.LeftHeaderDiv>
       <S.RightHeaderDiv>
         <S.SearchBar placeholder="Search" searchBar={searchBar} />
-        <S.HeaderImg profileImg={profileImg} />
+        <S.HeaderImg
+          aria-controls={open ? 'basic-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          onClick={handleClick}
+          profileImg={profileImg}
+        />
+
+        <Menu
+          anchorEl={anchorEl}
+          id="account-menu"
+          open={open}
+          onClose={handleClose}
+          onClick={handleClose}
+          PaperProps={{
+            elevation: 0,
+            sx: {
+              overflow: 'visible',
+              filter: 'drop-shadow(0px 2px 8px rgba(0,0,0,0.32))',
+              mt: 1.5,
+              '& .MuiAvatar-root': {
+                width: 32,
+                height: 32,
+                ml: -0.5,
+                mr: 1,
+              },
+              '&:before': {
+                content: '""',
+                display: 'block',
+                position: 'absolute',
+                top: 0,
+                right: 14,
+                width: 10,
+                height: 10,
+                bgcolor: 'background.paper',
+                transform: 'translateY(-50%) rotate(45deg)',
+                zIndex: 0,
+              },
+            },
+          }}
+          transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+          anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+        >
+          <MenuItem onClick={handleClose}>
+            <ListItemIcon>
+              <Settings fontSize="small" />
+            </ListItemIcon>
+            Settings
+          </MenuItem>
+          <MenuItem onClick={handleLogout}>
+            <ListItemIcon>
+              <Logout fontSize="small" />
+            </ListItemIcon>
+            Logout
+          </MenuItem>
+        </Menu>
       </S.RightHeaderDiv>
     </S.Header>
   );

--- a/src/pages/authorization/login/index.tsx
+++ b/src/pages/authorization/login/index.tsx
@@ -86,7 +86,7 @@ function Login() {
         <S.Header>
           <Default>
             <S.HeaderWrapper>
-              <S.BackBtn>
+              <S.BackBtn onClick={() => navigate(-1)}>
                 <img />
                 <span>Back</span>
               </S.BackBtn>

--- a/src/pages/authorization/login/styles.ts
+++ b/src/pages/authorization/login/styles.ts
@@ -48,6 +48,7 @@ export const Content = styled.div`
 export const BackBtn = styled.div`
   display: flex;
   align-items: center;
+  cursor: pointer;
   img {
     content: url('assets/authorization/login/arrow-right.png');
     width: 18px;

--- a/src/pages/authorization/sign-up/index.tsx
+++ b/src/pages/authorization/sign-up/index.tsx
@@ -138,7 +138,7 @@ export default function SignUp() {
         <S.Header>
           <Default>
             <S.HeaderWrapper>
-              <S.BackBtn>
+              <S.BackBtn onClick={() => navigate(-1)}>
                 <S.BackImg />
                 <span>Back</span>
               </S.BackBtn>

--- a/src/pages/authorization/sign-up/styles.ts
+++ b/src/pages/authorization/sign-up/styles.ts
@@ -39,6 +39,7 @@ export const HeaderWrapper = styled.div`
 export const BackBtn = styled.div`
   display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 export const BackImg = styled.img`

--- a/src/pages/util/index.tsx
+++ b/src/pages/util/index.tsx
@@ -1,10 +1,18 @@
-import { Link, useNavigate } from 'react-router-dom';
+import ROUTES from '@/routes';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import * as S from './styles';
 
 export default function Inform({ message }: { message: string }) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const hasPreviousState = location.key !== 'default';
+
   const handleClick = () => {
-    navigate(-1);
+    if (hasPreviousState) {
+      navigate(-1);
+    } else {
+      navigate(ROUTES.MAIN);
+    }
   };
   return (
     <S.Container>


### PR DESCRIPTION
## 라우팅 설정 및 모달 포탈 리팩토링 <!-- 소셜 로그인 구현 -->

### 지라 티켓 번호
PIM-91
<!-- PIM-xxxx -->

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 리팩토링
- [ ] UI 구현 및 변경

### 구현 내용
- 다른 도메인에서 에러페이지로 바로 접근했을 때, 이전 페이지를 누르면 메인페이지로 이동할 수 있도록 구현
- 헤더에서 로고 클릭시, 메인페이지로 라우팅 될 수 있도록 구현
- 로그인 및 회원가입 페이지에서 뒤로가기 버튼을 누르면 이전 페이지로 이동할 수 있도록 구현
- SubHeader에서 프로필 이미지 클릭 시, 드롭다운 메뉴가 나타나도록 구현
    - 로그아웃 구현 완료
- 포탈로 기존의 모달 컴포넌트 감싸기

<!-- 구글 소셜 로그인 연동 -->
<!-- 테스트 결과 포함 -->

### 리뷰 포인트
오류 있는지 함께 확인해주세요

### TODO
<!-- 추가적으로 테스트 코드를 작성할 예정입니다. -->
